### PR TITLE
feat: add support for auto-unpin on merged/closed, closes #5

### DIFF
--- a/src/contentScripts/issues.ts
+++ b/src/contentScripts/issues.ts
@@ -54,6 +54,14 @@ export function removeIssue(issue: Issue) {
 export function updateIssue(issue: Issue, hoist = true) {
   const target = getTargetCollection(issue)
   const existing = target.recent.find(i => i.id === issue.id)
+  const pinned = target.pinned.find(i => i.id === issue.id)
+
+  if (pinned) {
+    if (options.value.unpinClosed && isClosed(issue))
+      togglePinnedIssue(issue)
+    else
+      Object.assign(pinned, issue)
+  }
 
   if (existing) {
     if (options.value.excludeClosed && isClosed(issue)) {
@@ -61,6 +69,7 @@ export function updateIssue(issue: Issue, hoist = true) {
       target.recent.splice(index, 1)
       return
     }
+
     Object.assign(existing, issue)
     if (hoist) {
       const index = target.recent.indexOf(existing)

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,6 +7,7 @@ const defaultOptions: Options = {
   showOwnerName: true,
   githubDev: true,
   excludeClosed: true,
+  unpinClosed: true,
 }
 
 export const options = getCurrentContext() === 'background'

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface Options {
   showOwnerName: boolean
   githubDev: boolean
   excludeClosed: boolean
+  unpinClosed: boolean
 
   // TODO:
   accessToken?: string


### PR DESCRIPTION
Alright, here we go!

A couple of thoughts:

During local dev, I encountered GitHub's API rate limiting and had to temporarily modify the `fetch` utility to use a PAT. This is definitely an edge-case, as I had adjusted the TTL to a very small interval for testing purposes, but I imagine other devs _may_ run into this. In any case, have you considered adding an option to make authenticated requests? 

Second, do you plan on adding testing to this project? I'd be happy to write a few unit tests so we have coverage of this feature. 

Anyway, give me a shout if I can correct anything on this PR.  Thanks for letting me join in :)